### PR TITLE
Fix milliseconds timestamp

### DIFF
--- a/src/Inbox.ts
+++ b/src/Inbox.ts
@@ -312,7 +312,7 @@ export class Inbox implements InboxMethods {
       case undefined:
       case null:
       case 'milliseconds':
-        return date.getTime();
+        return date.getTime() / 1000;
 
       case 'day':
         return this.formatDate(date);


### PR DESCRIPTION
There is a problem in searching with timestamp.

See images bellow:

After PR (it found X messages):
http://prntscr.com/wj25xz

Before PR (it found 0 messages):
http://prntscr.com/wj26r7
