### PR TITLE
Remove numbers  after the dot in Unix Timestamp

### DIFF
--- a/src/Inbox.ts
+++ b/src/Inbox.ts
@@ -312,7 +312,7 @@ export class Inbox implements InboxMethods {
       case undefined:
       case null:
       case 'milliseconds':
-        return date.getTime() / 1000;
+        return Math.floor(date.getTime() / 1000);
 
       case 'day':
         return this.formatDate(date);


### PR DESCRIPTION
Sometimes timestamp could be like 1616413975059 so when we divide by 1000 the result is with dot 1616413975.059